### PR TITLE
AR 화면 여러 번 들어갈 때 발생하는 메모리 누수 해결

### DIFF
--- a/MC2-TEAM10-BURIBURI/Extrusion/ARViewContainer.swift
+++ b/MC2-TEAM10-BURIBURI/Extrusion/ARViewContainer.swift
@@ -71,6 +71,7 @@ struct ARViewContainer: UIViewRepresentable {
 //    }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(arView: self.arView, context: nil) // 새로운 코디네이터 생성
+        
+        return Coordinator(arView: self.arView, context: nil) // 새로운 코디네이터 생성
     }
 }

--- a/MC2-TEAM10-BURIBURI/Extrusion/Coordinator.swift
+++ b/MC2-TEAM10-BURIBURI/Extrusion/Coordinator.swift
@@ -17,7 +17,7 @@ class Coordinator: NSObject, ARSCNViewDelegate { // NSObject와 ARSCNViewDelegat
     static var scnNodeArray: [SCNNode] = []
     static var itemPlanArray: [Item] = []
     
-    var arView: ARSCNView?
+    weak var arView: ARSCNView?
     var context: ARViewContainer.Context?
     
     // Add a DispatchQueue specifically for accessing and modifying the scnNodeArray
@@ -83,7 +83,11 @@ class Coordinator: NSObject, ARSCNViewDelegate { // NSObject와 ARSCNViewDelegat
 
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(deleteObject(_:)))
         longPressGesture.minimumPressDuration = 0.5
-        arView?.addGestureRecognizer(longPressGesture)
+        DispatchQueue.main.async {
+            if let arView = self.arView {
+                arView.addGestureRecognizer(longPressGesture)
+            }
+        }
         
         
         registerGestureRecognizers()
@@ -133,8 +137,11 @@ class Coordinator: NSObject, ARSCNViewDelegate { // NSObject와 ARSCNViewDelegat
     private func registerGestureRecognizers() {
         
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapped))
-        
-        self.arView?.addGestureRecognizer(tapGestureRecognizer)
+        DispatchQueue.main.async {
+            if let arView = self.arView {
+                self.arView?.addGestureRecognizer(tapGestureRecognizer)
+            }
+        }
     }
     
     


### PR DESCRIPTION
Coordinator가 arView를 weak 참조하게 바꾸었습니다. 메모리 누수가 해결되었습니다.

화면 멈춤 문제는 화면을 다시 그리는 방식으로 해결해놓은 상태입니다.
* 화면이 가려지거나 앱이 숨겨지는 등의 경우에 무조건 ARView 화면을 다시 그립니다.
* 알림 센터를 잠시 보고 와도 ARView를 다시 그립니다. 그래서 소환한 그림들이 다 없어집니다.

ARView 세션 관리를 해서 소환한 그림들을 보존하면서 화면 멈춤을 해결하고 싶지만 세션 관리를 어떻게 하는지 도저히 모르겠습니다!
